### PR TITLE
Default font color in SourceCodeTheme changed to plain

### DIFF
--- a/Sources/Sourceful/SourceCodeTheme.swift
+++ b/Sources/Sourceful/SourceCodeTheme.swift
@@ -21,7 +21,7 @@ extension SourceCodeTheme {
 		var attributes = [NSAttributedString.Key: Any]()
 		
 		attributes[.font] = font
-		attributes[.foregroundColor] = Color.white
+        attributes[.foregroundColor] = color(for: .plain)
 		
 		return attributes
 	}


### PR DESCRIPTION
The SourceCodeTheme is not respecting the plain color defined in the SourceCodeTheme implementation. It defaults to white, no matter which color is set, resulting in a screen like the one attached:

![twitter_EN7_Zg1WkAAoj_z](https://user-images.githubusercontent.com/8977935/77212231-f59f8900-6acb-11ea-94a2-496e5a89255b.jpg)

The configuration used for the previous screenshot was the following:

![twitter_EN7_Zg3WkAALJPq](https://user-images.githubusercontent.com/8977935/77212264-15cf4800-6acc-11ea-8149-e5f6eaad3868.jpg)

As you can see, the text is not being showed even after we altered the plain color. By changing the default implementation from color white to obtaining the plain color, this is correctly fixed.