### PR TITLE
SourceCodeTextEditor  - SwiftUI wrapper for SyntaxTextView

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -6,8 +6,8 @@ import PackageDescription
 let package = Package(
     name: "Sourceful",
     platforms: [
-        .macOS(SupportedPlatform.MacOSVersion.v10_13),
-        .iOS(SupportedPlatform.IOSVersion.v12)
+        .macOS(SupportedPlatform.MacOSVersion.v10_15),
+        .iOS(SupportedPlatform.IOSVersion.v13)
     ],
     products: [
         // Products define the executables and libraries produced by a package, and make them visible to other packages.

--- a/Sources/Sourceful/SwiftUI/SourceCodeTextEditor.swift
+++ b/Sources/Sourceful/SwiftUI/SourceCodeTextEditor.swift
@@ -1,0 +1,117 @@
+//
+//  SourceCodeTextEditor.swift
+//
+//  Created by Andrew Eades on 14/08/2020.
+//
+
+import Foundation
+import Sourceful
+import SwiftUI
+
+#if os(macOS)
+public typealias _ViewRepresentable = NSViewRepresentable
+#endif
+
+#if os(iOS)
+public typealias _ViewRepresentable = UIViewRepresentable
+#endif
+
+
+public struct SourceCodeTextEditor: _ViewRepresentable {
+    
+    public struct Customization {
+        var didChangeText: (SourceCodeTextEditor) -> Void
+        var insertionPointColor: () -> Sourceful.Color
+        var lexerForSource: (String) -> Lexer
+        var textViewDidBeginEditing: (SourceCodeTextEditor) -> Void
+        var theme: () -> SourceCodeTheme
+        
+        /// Creates a **Customization** to pass into the *init()* of a **SourceCodeTextEditor**.
+        ///
+        /// - Parameters:
+        ///     - didChangeText: A SyntaxTextView delegate action.
+        ///     - lexerForSource: The lexer to use (default: SwiftLexer()).
+        ///     - insertionPointColor: To customize color of insertion point caret (default: .white).
+        ///     - textViewDidBeginEditing: A SyntaxTextView delegate action.
+        ///     - theme: Custom theme (default: DefaultSourceCodeTheme()).
+        public init(
+            didChangeText: @escaping (SourceCodeTextEditor) -> Void,
+            insertionPointColor: @escaping () -> Sourceful.Color,
+            lexerForSource: @escaping (String) -> Lexer,
+            textViewDidBeginEditing: @escaping (SourceCodeTextEditor) -> Void,
+            theme: @escaping () -> SourceCodeTheme
+        ) {
+            self.didChangeText = didChangeText
+            self.insertionPointColor = insertionPointColor
+            self.lexerForSource = lexerForSource
+            self.textViewDidBeginEditing = textViewDidBeginEditing
+            self.theme = theme
+        }
+    }
+    
+    @Binding private var text: String
+    
+    private var custom: Customization
+    
+    public init(
+        text: Binding<String>,
+        cusotmization: Customization = Customization(
+            didChangeText: {_ in },
+            insertionPointColor: { Sourceful.Color.white },
+            lexerForSource: { _ in SwiftLexer() },
+            textViewDidBeginEditing: { _ in },
+            theme: { DefaultSourceCodeTheme() }
+        )
+    ) {
+        self._text = text
+        self.custom = cusotmization
+    }
+    
+    public func makeCoordinator() -> Coordinator {
+        Coordinator(self)
+    }
+    
+    public func makeNSView(context: Context) -> SyntaxTextView {
+        let wrappedView = SyntaxTextView()
+        wrappedView.delegate = context.coordinator
+        wrappedView.theme = custom.theme()
+        wrappedView.contentTextView.insertionPointColor = custom.insertionPointColor()
+        
+        context.coordinator.wrappedView = wrappedView
+        context.coordinator.wrappedView.text = text
+        
+        return wrappedView
+    }
+    
+    public func updateNSView(_ view: SyntaxTextView, context: Context) {
+    }
+}
+
+extension SourceCodeTextEditor {
+    
+    public class Coordinator: SyntaxTextViewDelegate {
+        let parent: SourceCodeTextEditor
+        var wrappedView: SyntaxTextView!
+        
+        init(_ parent: SourceCodeTextEditor) {
+            self.parent = parent
+        }
+        
+        public func lexerForSource(_ source: String) -> Lexer {
+            parent.custom.lexerForSource(source)
+        }
+        
+        public func didChangeText(_ syntaxTextView: SyntaxTextView) {
+            DispatchQueue.main.async {
+                self.parent.text = syntaxTextView.text
+            }
+            
+            // allow the client to decide on thread
+            parent.custom.didChangeText(parent)
+        }
+        
+        public func textViewDidBeginEditing(_ syntaxTextView: SyntaxTextView) {
+            parent.custom.textViewDidBeginEditing(parent)
+        }
+    }
+}

--- a/Sources/Sourceful/SwiftUI/SourceCodeTextEditor.swift
+++ b/Sources/Sourceful/SwiftUI/SourceCodeTextEditor.swift
@@ -5,15 +5,21 @@
 //
 
 import Foundation
-import Sourceful
+
+#if canImport(SwiftUI)
+
 import SwiftUI
 
 #if os(macOS)
+
 public typealias _ViewRepresentable = NSViewRepresentable
+
 #endif
 
 #if os(iOS)
+
 public typealias _ViewRepresentable = UIViewRepresentable
+
 #endif
 
 
@@ -71,6 +77,24 @@ public struct SourceCodeTextEditor: _ViewRepresentable {
         Coordinator(self)
     }
     
+    #if os(iOS)
+    public func makeUIView(context: Context) -> SyntaxTextView {
+        let wrappedView = SyntaxTextView()
+        wrappedView.delegate = context.coordinator
+        wrappedView.theme = custom.theme()
+//        wrappedView.contentTextView.insertionPointColor = custom.insertionPointColor()
+        
+        context.coordinator.wrappedView = wrappedView
+        context.coordinator.wrappedView.text = text
+        
+        return wrappedView
+    }
+    
+    public func updateUIView(_ view: SyntaxTextView, context: Context) {
+    }
+    #endif
+    
+    #if os(macOS)
     public func makeNSView(context: Context) -> SyntaxTextView {
         let wrappedView = SyntaxTextView()
         wrappedView.delegate = context.coordinator
@@ -85,6 +109,9 @@ public struct SourceCodeTextEditor: _ViewRepresentable {
     
     public func updateNSView(_ view: SyntaxTextView, context: Context) {
     }
+    #endif
+    
+
 }
 
 extension SourceCodeTextEditor {
@@ -115,3 +142,5 @@ extension SourceCodeTextEditor {
         }
     }
 }
+
+#endif

--- a/Sources/Sourceful/Util/Types.swift
+++ b/Sources/Sourceful/Util/Types.swift
@@ -12,7 +12,7 @@ import Foundation
 	
 	import AppKit
 	
-	public typealias View			= NSView
+	public typealias _View			= NSView
 	public typealias ViewController = NSViewController
 	public typealias Window			= NSWindow
 	public typealias Control		= NSControl
@@ -31,7 +31,7 @@ import Foundation
 	
 	import UIKit
 	
-	public typealias View			= UIView
+	public typealias _View			= UIView
 	public typealias ViewController = UIViewController
 	public typealias Window			= UIWindow
 	public typealias Control		= UIControl

--- a/Sources/Sourceful/View/SyntaxTextView.swift
+++ b/Sources/Sourceful/View/SyntaxTextView.swift
@@ -47,7 +47,7 @@ struct ThemeInfo {
 }
 
 @IBDesignable
-open class SyntaxTextView: View {
+open class SyntaxTextView: _View {
 
     var previousSelectedRange: NSRange?
 

--- a/Sources/Sourceful/View/TextViewWrapperView.swift
+++ b/Sources/Sourceful/View/TextViewWrapperView.swift
@@ -16,7 +16,7 @@ import Foundation
 
 #if os(macOS)
 	
-	class TextViewWrapperView: View {
+	class TextViewWrapperView: _View {
 		
 		override func hitTest(_ point: NSPoint) -> NSView? {
 			// Disable interaction, so we're not blocking the text view.


### PR DESCRIPTION
I've made a SourceCodeTextEditor (to follow the naming of the new TextEditor view).

I think it is pretty self-explanatory. You can  customise on creation but it has defaults that make it work out of the box.

```
// text storage
@State private var text = ""
...
var body: some View {
...
  SourceCodeTextEditor(text: $text)
...
}

```
