### PR TITLE
Add async await syntax

### DIFF
--- a/Sources/Sourceful/Languages/SwiftLexer.swift
+++ b/Sources/Sourceful/Languages/SwiftLexer.swift
@@ -29,7 +29,7 @@ public class SwiftLexer: SourceCodeRegexLexer {
 		
 		generators.append(regexGenerator("\\.[A-Za-z_]+\\w*", tokenType: .identifier))
 		
-		let keywords = "as associatedtype break case catch class continue convenience default defer deinit else enum extension fallthrough false fileprivate final for func get guard if import in init inout internal is lazy let mutating nil nonmutating open operator override private protocol public repeat required rethrows return required self set static struct subscript super switch throw throws true try typealias unowned var weak where while async await".components(separatedBy: " ")
+		let keywords = "as associatedtype async await break case catch class continue convenience default defer deinit else enum extension fallthrough false fileprivate final for func get guard if import in init inout internal is lazy let mutating nil nonmutating open operator override private protocol public repeat required rethrows return required self set static struct subscript super switch throw throws true try typealias unowned var weak where while".components(separatedBy: " ")
 		
 		generators.append(keywordGenerator(keywords, tokenType: .keyword))
 		

--- a/Sources/Sourceful/Languages/SwiftLexer.swift
+++ b/Sources/Sourceful/Languages/SwiftLexer.swift
@@ -29,7 +29,7 @@ public class SwiftLexer: SourceCodeRegexLexer {
 		
 		generators.append(regexGenerator("\\.[A-Za-z_]+\\w*", tokenType: .identifier))
 		
-		let keywords = "as associatedtype break case catch class continue convenience default defer deinit else enum extension fallthrough false fileprivate final for func get guard if import in init inout internal is lazy let mutating nil nonmutating open operator override private protocol public repeat required rethrows return required self set static struct subscript super switch throw throws true try typealias unowned var weak where while".components(separatedBy: " ")
+		let keywords = "as associatedtype break case catch class continue convenience default defer deinit else enum extension fallthrough false fileprivate final for func get guard if import in init inout internal is lazy let mutating nil nonmutating open operator override private protocol public repeat required rethrows return required self set static struct subscript super switch throw throws true try typealias unowned var weak where while async await".components(separatedBy: " ")
 		
 		generators.append(keywordGenerator(keywords, tokenType: .keyword))
 		

--- a/Sources/Sourceful/View/InnerTextView.swift
+++ b/Sources/Sourceful/View/InnerTextView.swift
@@ -15,7 +15,7 @@ import CoreGraphics
 	import UIKit
 #endif
 
-protocol InnerTextViewDelegate: class {
+protocol InnerTextViewDelegate: AnyObject {
 	func didUpdateCursorFloatingState()
 }
 

--- a/Sources/Sourceful/View/SyntaxTextView.swift
+++ b/Sources/Sourceful/View/SyntaxTextView.swift
@@ -15,7 +15,7 @@ import AppKit
 import UIKit
 #endif
 
-public protocol SyntaxTextViewDelegate: class {
+public protocol SyntaxTextViewDelegate: AnyObject {
 
     func didChangeText(_ syntaxTextView: SyntaxTextView)
 


### PR DESCRIPTION
* support `async` `await` syntax highlighting
* replace `class` constraint with `AnyObject` to get rid of the deprecation warning