### PR TITLE
Remove delegate callback for programmatic changes to text

### DIFF
--- a/Sources/Sourceful/View/SyntaxTextView+TextViewDelegate.swift
+++ b/Sources/Sourceful/View/SyntaxTextView+TextViewDelegate.swift
@@ -136,7 +136,13 @@ extension SyntaxTextView {
 		}
 		
 	}
-	
+    
+    func didUpdateText() {
+        
+        refreshColors()
+        delegate?.didChangeText(self)
+        
+    }
 }
 
 #if os(macOS)
@@ -156,24 +162,20 @@ extension SyntaxTextView {
 			}
 			
 			didUpdateText()
-			
 		}
-		
-		func didUpdateText() {
-			
-			self.invalidateCachedTokens()
-			self.textView.invalidateCachedParagraphs()
-			
-			if let delegate = delegate {
-				colorTextView(lexerForSource: { (source) -> Lexer in
-					return delegate.lexerForSource(source)
-				})
-			}
-			
-			wrapperView.setNeedsDisplay(wrapperView.bounds)
-			self.delegate?.didChangeText(self)
-			
-		}
+        
+        func refreshColors() {
+            self.invalidateCachedTokens()
+            self.textView.invalidateCachedParagraphs()
+            
+            if let delegate = delegate {
+                colorTextView(lexerForSource: { (source) -> Lexer in
+                    return delegate.lexerForSource(source)
+                })
+            }
+            
+            wrapperView.setNeedsDisplay(wrapperView.bounds)
+        }
 		
 		open func textViewDidChangeSelection(_ notification: Notification) {
 			
@@ -205,7 +207,7 @@ extension SyntaxTextView {
 			
 		}
 		
-		func didUpdateText() {
+		func refreshColors() {
 			
 			self.invalidateCachedTokens()
 			self.textView.invalidateCachedParagraphs()
@@ -215,9 +217,6 @@ extension SyntaxTextView {
 				colorTextView(lexerForSource: { (source) -> Lexer in
 					return delegate.lexerForSource(source)
 				})
-				
-				delegate.didChangeText(self)
-
 			}
 			
 		}

--- a/Sources/Sourceful/View/SyntaxTextView.swift
+++ b/Sources/Sourceful/View/SyntaxTextView.swift
@@ -61,7 +61,7 @@ open class SyntaxTextView: _View {
 
     public weak var delegate: SyntaxTextViewDelegate? {
         didSet {
-            didUpdateText()
+            refreshColors()
         }
     }
 
@@ -292,13 +292,13 @@ open class SyntaxTextView: _View {
             #if os(macOS)
             textView.layer?.isOpaque = true
             textView.string = newValue
-            self.didUpdateText()
+            refreshColors()
             #else
             // If the user sets this property as soon as they create the view, we get a strange UIKit bug where the text often misses a final line in some Dynamic Type configurations. The text isn't actually missing: if you background the app then foreground it the text reappears just fine, so there's some sort of drawing sync problem. A simple fix for this is to give UIKit a tiny bit of time to create all its data before we trigger the update, so we push the updating work to the runloop.
             DispatchQueue.main.async {
                 self.textView.text = newValue
                 self.textView.setNeedsDisplay()
-                self.didUpdateText()
+                self.refreshColors()
             }
             #endif
 
@@ -346,7 +346,7 @@ open class SyntaxTextView: _View {
             textView.theme = theme
             textView.font = theme.font
 
-            didUpdateText()
+            refreshColors()
         }
     }
 

--- a/Tests/SourcefulTests/SourcefulTests.swift
+++ b/Tests/SourcefulTests/SourcefulTests.swift
@@ -2,11 +2,31 @@ import XCTest
 @testable import Sourceful
 
 final class SourcefulTests: XCTestCase {
-    func testExample() {
-        // This is an example of a functional test case.
+    func testSyntaxTextViewDelegateDidChangeTextShouldNotBeCalledWhenSetProgrammatically() {
+        let textView = SyntaxTextView()
+        textView.delegate = TestDelegate(didChangeText: {
+            XCTFail("Delegate's didChangeText should not be called when text is set programmatically.")
+        })
+        textView.text = "My new text"
     }
 
     static var allTests = [
-        ("testExample", testExample),
+        ("testSyntaxTextViewDelegateDidChangeTextShouldNotBeCalledWhenSetProgrammatically", testSyntaxTextViewDelegateDidChangeTextShouldNotBeCalledWhenSetProgrammatically),
     ]
+}
+
+class TestDelegate: SyntaxTextViewDelegate {
+    var didChangeText: () -> Void
+    
+    func didChangeText(_ syntaxTextView: SyntaxTextView) {
+        didChangeText()
+    }
+    
+    func lexerForSource(_ source: String) -> Lexer {
+        SwiftLexer()
+    }
+    
+    init(didChangeText: @escaping () -> Void) {
+        self.didChangeText = didChangeText
+    }
 }

--- a/Tests/SourcefulTests/SourcefulTests.swift
+++ b/Tests/SourcefulTests/SourcefulTests.swift
@@ -2,11 +2,13 @@ import XCTest
 @testable import Sourceful
 
 final class SourcefulTests: XCTestCase {
+    let testDelegate = TestDelegate(didChangeText: {
+        XCTFail("Delegate's didChangeText should not be called when text is set programmatically.")
+    })
+    
     func testSyntaxTextViewDelegateDidChangeTextShouldNotBeCalledWhenSetProgrammatically() {
         let textView = SyntaxTextView()
-        textView.delegate = TestDelegate(didChangeText: {
-            XCTFail("Delegate's didChangeText should not be called when text is set programmatically.")
-        })
+        textView.delegate = testDelegate
         textView.text = "My new text"
     }
 


### PR DESCRIPTION
This fixes #20 by removing the delegate callback when text is changed programmatically. This matches the pattern set by other UIKit controls' delegates like `UITextViewDelegate`. Per [Apple's UITextViewDelegate documentation on `textViewDidChange`](https://developer.apple.com/documentation/uikit/uitextviewdelegate/1618599-textviewdidchange):
> The text view calls this method in response to user-initiated changes to the text. This method is not called in response to programmatically initiated changes.

  This will make it easier to support other SwiftUI features and to fix some of the other existing SwiftUI bugs. I also added a unit test to prevent regressions.