### PR TITLE
Update text when binding changes

### DIFF
--- a/Sources/Sourceful/SwiftUI/SourceCodeTextEditor.swift
+++ b/Sources/Sourceful/SwiftUI/SourceCodeTextEditor.swift
@@ -96,6 +96,7 @@ public struct SourceCodeTextEditor: _ViewRepresentable {
         if shouldBecomeFirstResponder {
             view.becomeFirstResponder()
         }
+        view.text = text
     }
     #endif
     
@@ -113,7 +114,7 @@ public struct SourceCodeTextEditor: _ViewRepresentable {
     }
     
     public func updateNSView(_ view: SyntaxTextView, context: Context) {
-       
+        view.text = text
     }
     #endif
     


### PR DESCRIPTION
Fixes #21. This updates the text in the `UIView`/`NSView` when the text binding is updated externally. Currently, any binding change does not get propagated through, so any external change to the binding will not be reflected in the source code view.