### PR TITLE
add actor and nonisolated keyword for swift 5.5

### DIFF
--- a/Sources/Sourceful/Languages/SwiftLexer.swift
+++ b/Sources/Sourceful/Languages/SwiftLexer.swift
@@ -29,7 +29,7 @@ public class SwiftLexer: SourceCodeRegexLexer {
 		
 		generators.append(regexGenerator("\\.[A-Za-z_]+\\w*", tokenType: .identifier))
 		
-		let keywords = "as associatedtype async await actor noisolated break case catch class continue convenience default defer deinit do else enum extension fallthrough false fileprivate final for func get guard if import in init inout internal is lazy let mutating nil nonmutating open operator override private protocol public repeat required rethrows return required self set static struct subscript super switch throw throws true try typealias unowned var weak where while".components(separatedBy: " ")
+		let keywords = "as associatedtype async await actor nonisolated break case catch class continue convenience default defer deinit do else enum extension fallthrough false fileprivate final for func get guard if import in init inout internal is lazy let mutating nil nonmutating open operator override private protocol public repeat required rethrows return required self set static struct subscript super switch throw throws true try typealias unowned var weak where while".components(separatedBy: " ")
 		
 		generators.append(keywordGenerator(keywords, tokenType: .keyword))
 		

--- a/Sources/Sourceful/Languages/SwiftLexer.swift
+++ b/Sources/Sourceful/Languages/SwiftLexer.swift
@@ -29,7 +29,7 @@ public class SwiftLexer: SourceCodeRegexLexer {
 		
 		generators.append(regexGenerator("\\.[A-Za-z_]+\\w*", tokenType: .identifier))
 		
-		let keywords = "as associatedtype async await break case catch class continue convenience default defer deinit do else enum extension fallthrough false fileprivate final for func get guard if import in init inout internal is lazy let mutating nil nonmutating open operator override private protocol public repeat required rethrows return required self set static struct subscript super switch throw throws true try typealias unowned var weak where while".components(separatedBy: " ")
+		let keywords = "as associatedtype async await actor noisolated break case catch class continue convenience default defer deinit do else enum extension fallthrough false fileprivate final for func get guard if import in init inout internal is lazy let mutating nil nonmutating open operator override private protocol public repeat required rethrows return required self set static struct subscript super switch throw throws true try typealias unowned var weak where while".components(separatedBy: " ")
 		
 		generators.append(keywordGenerator(keywords, tokenType: .keyword))
 		


### PR DESCRIPTION
- support ```actor``` & ```nonisolated``` to highlight them.

https://docs.swift.org/swift-book/LanguageGuide/Concurrency.html#ID645

```
actor BankAccount {
  nonisolated let accountNumber: Int
  var balance: Double

  // ...
}
```