### PR TITLE
Support TextView Insertion Point Color on Mac Catalyst

### DIFF
--- a/Sources/Sourceful/View/SyntaxTextView.swift
+++ b/Sources/Sourceful/View/SyntaxTextView.swift
@@ -84,7 +84,10 @@ open class SyntaxTextView: _View {
 
     open override var tintColor: UIColor! {
         didSet {
-
+            #if targetEnvironment(macCatalyst)
+            let textInputTraits = textView.value(forKey: "textInputTraits") as? NSObject
+            textInputTraits?.setValue(tintColor, forKey: "insertionPointColor")
+            #endif
         }
     }
 


### PR DESCRIPTION
Mac Catalyst only:
TextView Insertion Point Color changing on tintColor didSet of SyntaxTextView.