### PR TITLE
Fix Python3Lexer .identifier regex

### DIFF
--- a/Sources/Sourceful/Languages/Python3Lexer.swift
+++ b/Sources/Sourceful/Languages/Python3Lexer.swift
@@ -23,7 +23,7 @@ public class Python3Lexer: SourceCodeRegexLexer {
 		
 		generators.append(regexGenerator("(?<=[^a-zA-Z])\\d+", tokenType: .number))
 		
-		generators.append(regexGenerator("\\.\\w+", tokenType: .identifier))
+		generators.append(regexGenerator("(?<=\\.)[A-Za-z_]+\\w*", tokenType: .identifier))
 		
 		let keywords = "False None True and as assert break class continue def del elif else except finally for from global if import in is lambda nonlocal not or pass raise return try while with yield".components(separatedBy: " ")
         


### PR DESCRIPTION
This fixes two bugs of the Python lexer:
![before](https://github.com/twostraws/Sourceful/assets/12122389/759492f6-99eb-4076-93b0-c487d7444f71)
1. In function calls, e.g., `np.zeros(5, 5)` in line 3, the dot was falsely highlighted.
2. In decimal numbers, e.g., `1.5` in line 5, the digit after the decimal point was falsely highlighted in a different colour than the digit before the decimal point.

By modifying the regular expression for `tokenType: .identifier`, both of these bugs are fixed:
![after](https://github.com/twostraws/Sourceful/assets/12122389/b99bfb5b-5e5b-44c0-b673-05419d9546a3)